### PR TITLE
La til hjelpefunksjon for utlede context path for interne URLer

### DIFF
--- a/src/component/page/bruker-detaljer/BrukerPaaTiltakDetaljer.tsx
+++ b/src/component/page/bruker-detaljer/BrukerPaaTiltakDetaljer.tsx
@@ -8,6 +8,7 @@ import globalStyles from '../../../globals.module.less'
 import { lagBrukerNavn } from '../../../utils/bruker-utils'
 import { formatDate } from '../../../utils/date-utils'
 import { mapTiltakDeltagerStatusTilEtikett } from '../../../utils/text-mappers'
+import { internalUrl } from '../../../utils/url-utils'
 import { Card } from '../../felles/card/Card'
 import styles from './BrukerPaaTiltakDetaljer.module.less'
 import { KopierKnapp } from './kopier-knapp/KopierKnapp'
@@ -19,7 +20,7 @@ export const BrukerPaaTiltakDetaljer = (props: { bruker: TiltakDeltakerDetaljer 
 		<>
 			<div className={styles.header}>
 				<div className={styles.headerContent}>
-					<Link to={`/instans/${tiltakInstans.id}`} className={styles.tilbakeknapp}>
+					<Link to={internalUrl(`/instans/${tiltakInstans.id}`)} className={styles.tilbakeknapp}>
 						<Tilbakeknapp />
 					</Link>
 					<Systemtittel className={styles.headerTitle}>{lagBrukerNavn(fornavn, etternavn)}</Systemtittel>

--- a/src/component/page/tiltakinstans-detaljer/deltaker-oversikt/Rad.tsx
+++ b/src/component/page/tiltakinstans-detaljer/deltaker-oversikt/Rad.tsx
@@ -5,6 +5,7 @@ import { TiltakDeltaker } from '../../../../domeneobjekter/deltaker'
 import { lagKommaSeparertBrukerNavn } from '../../../../utils/bruker-utils'
 import { formatDate } from '../../../../utils/date-utils'
 import { mapTiltakDeltagerStatusTilTekst } from '../../../../utils/text-mappers'
+import { internalUrl } from '../../../../utils/url-utils'
 import styles from './Rad.module.less'
 
 interface RadProps {
@@ -18,7 +19,7 @@ export const Rad = (props: RadProps): React.ReactElement<RadProps> => {
 	return (
 		<tr key={id}>
 			<td>
-				<Link className={styles.brukersNavn} to={`/user/${id}`}>
+				<Link className={styles.brukersNavn} to={internalUrl(`/user/${id}`)}>
 					{lagKommaSeparertBrukerNavn(fornavn, etternavn)}
 				</Link>
 			</td>

--- a/src/component/page/tiltakinstans-oversikt/tiltakinstans-liste/tiltakinstans-oversikt-panel/TiltakinstansOversiktPanel.tsx
+++ b/src/component/page/tiltakinstans-oversikt/tiltakinstans-liste/tiltakinstans-oversikt-panel/TiltakinstansOversiktPanel.tsx
@@ -1,6 +1,7 @@
 import { Undertittel } from 'nav-frontend-typografi'
 import React from 'react'
 
+import { internalUrl } from '../../../../../utils/url-utils'
 import { SpaLenkepanel } from '../../../../felles/SpaLenkepanel'
 import styles from './TiltakinstansOversiktPanel.module.less'
 
@@ -13,7 +14,7 @@ export const TiltakinstansOversiktPanel = (props: TiltakinstansOversiktPanelProp
 	const { id, navn } = props
 
 	return (
-		<SpaLenkepanel to={`/instans/${id}`} border>
+		<SpaLenkepanel to={internalUrl(`/instans/${id}`)} border>
 			<div className={styles.content} >
 				<Undertittel>{navn}</Undertittel>
 			</div>

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,5 +1,6 @@
 import { setupWorker } from 'msw'
 
+import { internalUrl } from '../utils/url-utils'
 import { devProxyHandlers } from './handlers/dev-proxy-handlers'
 import { mockHandlers } from './handlers/mock-handlers'
 import { getDevProxyEnabled } from './utils/dev-proxy-env'
@@ -9,7 +10,7 @@ const handlers = getDevProxyEnabled()
 	: mockHandlers
 
 setupWorker(...handlers)
-	.start({ serviceWorker: { url: process.env.PUBLIC_URL + '/mockServiceWorker.js' } })
+	.start({ serviceWorker: { url: internalUrl('mockServiceWorker.js') } })
 	.catch((e) => {
 		// eslint-disable-next-line no-console
 		console.error('Unable to setup mocked API endpoints', e)

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -17,6 +17,10 @@ class Environment {
 		return window.location.hostname.endsWith('github.io')
 	}
 
+	get publicUrl(): string {
+		return process.env.PUBLIC_URL || ''
+	}
+
 	get name(): string {
 		if (this.isProd) {
 			return 'production'

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,0 +1,6 @@
+import environment from './environment'
+
+export const internalUrl = (path: string): string => {
+	const strippedPath = path.startsWith('/') ? path.substr(1) : path
+	return `${environment.publicUrl}/${strippedPath}`
+}


### PR DESCRIPTION
Siden demoappen kjører med context path og vi vanligvis kjører uten så må vi prefikse interne URLer med context path basert på PUBLIC_URL