### PR TITLE
Fikset deltakertabell styling

### DIFF
--- a/src/component/felles/menu/Banner.module.less
+++ b/src/component/felles/menu/Banner.module.less
@@ -20,7 +20,5 @@
 }
 
 .logoutBtn {
-  padding-top: 0;
-  padding-bottom: 0;
   min-height: 1.5rem !important;
 }

--- a/src/component/page/tiltakinstans-detaljer/deltaker-oversikt/DeltakerOversiktTabell.tsx
+++ b/src/component/page/tiltakinstans-detaljer/deltaker-oversikt/DeltakerOversiktTabell.tsx
@@ -33,9 +33,11 @@ export const DeltakerOversiktTabell = (props: DeltakerOversiktTabellProps): Reac
 	}
 
 	return (
-		<table className="tabell">
-			<TabellHeader />
-			<TabellBody brukere={deltakereBearbeidet} />
-		</table>
+		<section>
+			<table className="tabell">
+				<TabellHeader />
+				<TabellBody brukere={deltakereBearbeidet} />
+			</table>
+		</section>
 	)
 }


### PR DESCRIPTION
Istedenfor at tabellen alltid tar hele plassen så kan vi wrappe med en ny tag slik at tabellen kun tar plassen den trenger