### PR TITLE
Forhindre sideklikk når token er utløpt

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
   ],
   "plugins": [
     "@typescript-eslint",
-    "simple-import-sort",
     "react-hooks",
     "jsx-a11y"
   ],
@@ -31,7 +30,6 @@
     "object-curly-spacing": [2, "always"],
     "quotes": [2, "single", { "avoidEscape": true }],
     "semi": ["error", "never"],
-    "simple-import-sort/imports": "error",
     "sort-imports": "off",
     "import/order": "off",
     "no-control-regex": "off",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
     "faker": "5.5.3",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,6 @@ specifiers:
   eslint-plugin-jsx-a11y: ^6.6.1
   eslint-plugin-react: ^7.31.11
   eslint-plugin-react-hooks: ^4.6.0
-  eslint-plugin-simple-import-sort: ^7.0.0
   faker: 5.5.3
   husky: ^7.0.4
   lint-staged: ^12.1.7
@@ -90,7 +89,6 @@ devDependencies:
   eslint-plugin-jsx-a11y: 6.6.1_eslint@8.30.0
   eslint-plugin-react: 7.31.11_eslint@8.30.0
   eslint-plugin-react-hooks: 4.6.0_eslint@8.30.0
-  eslint-plugin-simple-import-sort: 7.0.0_eslint@8.30.0
   faker: 5.5.3
   husky: 7.0.4
   lint-staged: 12.5.0
@@ -836,6 +834,9 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.30 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
     dependencies:
       '@types/react': 18.0.26
       react: 18.2.0
@@ -846,6 +847,9 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.30 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
     dependencies:
       '@navikt/ds-icons': 2.1.0_kzbn2opkn2327fwg5yzwzya5o4
       '@navikt/ds-react': 2.1.0_ib3m5ricvtkl2cll7qpr2f6lvq
@@ -862,6 +866,9 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.30 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
     dependencies:
       '@floating-ui/react': 0.17.0_ib3m5ricvtkl2cll7qpr2f6lvq
       '@navikt/ds-icons': 2.1.0_kzbn2opkn2327fwg5yzwzya5o4
@@ -2652,14 +2659,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.0
       string.prototype.matchall: 4.0.8
-    dev: true
-
-  /eslint-plugin-simple-import-sort/7.0.0_eslint@8.30.0:
-    resolution: {integrity: sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==}
-    peerDependencies:
-      eslint: '>=5.0.0'
-    dependencies:
-      eslint: 8.30.0
     dev: true
 
   /eslint-scope/5.1.1:

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -14,12 +14,14 @@ import { SesjonNotifikasjon } from './component/sesjon-notifikasjon/SesjonNotifi
 import { Driftsmelding } from './Driftsmelding'
 import {
 	DELTAKER_DETALJER_PAGE_ROUTE,
+	DU_ER_LOGGET_UT_PAGE_ROUTE,
 	GJENNOMFORING_DETALJER_PAGE_ROUTE,
 	GJENNOMFORING_LISTE_PAGE_ROUTE,
 	INFORMASJON_PAGE_ROUTE, INGEN_ROLLE_PAGE_ROUTE,
 	LEGG_TIL_DELTAKERLISTE_PAGE_ROUTE,
 	PERSONOPPLYSNINGER_PAGE_ROUTE
 } from './navigation'
+import { LoggetUtPage } from './component/page/LoggetUtPage'
 
 
 interface AppRoutesProps {
@@ -47,6 +49,7 @@ const PrivateRoutes = (): React.ReactElement => {
 				<Route path={GJENNOMFORING_LISTE_PAGE_ROUTE} element={<GjennomforingListePage />} />
 				<Route path={LEGG_TIL_DELTAKERLISTE_PAGE_ROUTE} element={<LeggTilDeltakerlistePage />} />
 				<Route path={PERSONOPPLYSNINGER_PAGE_ROUTE} element={<PersonopplysningerPage />} />
+				<Route path={DU_ER_LOGGET_UT_PAGE_ROUTE} element={<LoggetUtPage/>}/>
 				<Route path="*" element={<Navigate replace to={GJENNOMFORING_LISTE_PAGE_ROUTE}/>} />
 			</Routes>
 		</>

--- a/src/component/page/LoggetUtPage.tsx
+++ b/src/component/page/LoggetUtPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+// Laster tom side for å unngå videre navigasjon etter at token har utgått
+// SesjonNotifikasjon alertstripe vil vises øverst
+export const LoggetUtPage = () => {
+	return <div/>
+}

--- a/src/component/sesjon-notifikasjon/SesjonNotifikasjon.tsx
+++ b/src/component/sesjon-notifikasjon/SesjonNotifikasjon.tsx
@@ -74,7 +74,7 @@ export const SesjonNotifikasjon = (): React.ReactElement | null => {
 		if (!tvungenUtloggingOmMs) return
 
 		tvungenUtloggingTimeoutRef.current = setTimeout(() => {
-			window.location.href = loginUrl(GJENNOMFORING_LISTE_PAGE_ROUTE)
+			window.location.href = loginUrl(window.location.href) //denne fungerer ikke om fanen ikke er aktiv
 			navigate(DU_ER_LOGGET_UT_PAGE_ROUTE)
 		}, tvungenUtloggingOmMs) as unknown as number
 
@@ -83,7 +83,7 @@ export const SesjonNotifikasjon = (): React.ReactElement | null => {
 
 	if (sesjonStatus === undefined) return null
 
-	const LoginLenke = () => <Link href={loginUrl(window.location.href)} className={styles.loginLenke}>Logg inn på nytt</Link>
+	const LoginLenke = () => <Link href={loginUrl(GJENNOMFORING_LISTE_PAGE_ROUTE)} className={styles.loginLenke}>Logg inn på nytt</Link>
 
 	return (
 		<div className={styles.alertWrapper}>

--- a/src/component/sesjon-notifikasjon/SesjonNotifikasjon.tsx
+++ b/src/component/sesjon-notifikasjon/SesjonNotifikasjon.tsx
@@ -1,5 +1,5 @@
 import { Alert, Link } from '@navikt/ds-react'
-import { AxiosError, AxiosResponse } from 'axios'
+import { AxiosResponse } from 'axios'
 import dayjs from 'dayjs'
 import React, { useEffect, useRef, useState } from 'react'
 
@@ -8,6 +8,8 @@ import { AuthInfo } from '../../api/data/auth'
 import { loginUrl } from '../../utils/url-utils'
 import { usePromise } from '../../utils/use-promise'
 import styles from './SesjonNotifikasjon.module.scss'
+import { useNavigate } from 'react-router-dom'
+import { DU_ER_LOGGET_UT_PAGE_ROUTE, GJENNOMFORING_LISTE_PAGE_ROUTE } from '../../navigation'
 
 enum SesjonStatus {
 	UTLOPER_SNART,
@@ -19,15 +21,14 @@ export const SesjonNotifikasjon = (): React.ReactElement | null => {
 	const [ utlopAlertOmMs, setUtlopAlertOmMs ] = useState<number>()
 	const [ utloggingAlertOmMs, setUtloggingAlertOmMs ] = useState<number>()
 	const [ tvungenUtloggingOmMs, setTvungenUtloggingOmMs ] = useState<number>()
-	const fetchAuthInfo = usePromise<AxiosResponse<AuthInfo>, AxiosError>(hentAuthInfo)
+	const fetchAuthInfo = usePromise<AxiosResponse<AuthInfo>>(hentAuthInfo)
+	const navigate = useNavigate()
 
 	const tvungenUtloggingTimeoutRef = useRef<number>()
 	const tvungenUtloggingAlertTimeoutRef = useRef<number>()
 	const utloperSnartAlertTimeoutRef = useRef<number>()
 
 	const expirationTime = fetchAuthInfo.result?.data.expirationTime
-	const visTvungen = sesjonStatus === SesjonStatus.TVUNGEN_UTLOGGING_SNART
-	const visUtloper = sesjonStatus === SesjonStatus.UTLOPER_SNART
 
 	useEffect(() => {
 		if (!expirationTime) return
@@ -73,25 +74,26 @@ export const SesjonNotifikasjon = (): React.ReactElement | null => {
 		if (!tvungenUtloggingOmMs) return
 
 		tvungenUtloggingTimeoutRef.current = setTimeout(() => {
-			window.location.href = loginUrl()
+			window.location.href = loginUrl(GJENNOMFORING_LISTE_PAGE_ROUTE)
+			navigate(DU_ER_LOGGET_UT_PAGE_ROUTE)
 		}, tvungenUtloggingOmMs) as unknown as number
 
 		return () => clearTimeout(tvungenUtloggingTimeoutRef.current)
-	}, [ sesjonStatus, tvungenUtloggingOmMs ])
+	}, [ sesjonStatus, tvungenUtloggingOmMs, navigate ])
 
 	if (sesjonStatus === undefined) return null
 
-	const LoginLenke = () => <Link href={loginUrl()} className={styles.loginLenke}>Logg inn på nytt</Link>
+	const LoginLenke = () => <Link href={loginUrl(window.location.href)} className={styles.loginLenke}>Logg inn på nytt</Link>
 
 	return (
 		<div className={styles.alertWrapper}>
-			{visTvungen &&
+			{sesjonStatus === SesjonStatus.TVUNGEN_UTLOGGING_SNART &&
 				<Alert variant="error" role="alert">
 					Du blir logget ut nå, og må logge inn på ny.
 					<LoginLenke />
 				</Alert>
 			}
-			{visUtloper &&
+			{sesjonStatus === SesjonStatus.UTLOPER_SNART &&
 				<Alert variant="warning" role="alert">
 					Du blir snart logget ut
 					<LoginLenke />

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -6,6 +6,8 @@ export const INFORMASJON_PAGE_ROUTE = appUrl('/informasjon')
 export const PERSONOPPLYSNINGER_PAGE_ROUTE = appUrl('/personopplysninger')
 export const INGEN_ROLLE_PAGE_ROUTE = appUrl('/ingen-rolle')
 export const LEGG_TIL_DELTAKERLISTE_PAGE_ROUTE = appUrl('/legg-til-deltakerliste')
+export const DU_ER_LOGGET_UT_PAGE_ROUTE = appUrl('/du-er-logget-ut')
+
 export const GJENNOMFORING_LISTE_PAGE_ROUTE = appUrl('/')
 
 export const HOVED_PAGE_ROUTE = appUrl('/')

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -5,5 +5,5 @@ export const appUrl = (path: string): string => {
 	return `${environment.baseUrl}${strippedPath}`
 }
 
-export const loginUrl = () => appUrl(`/oauth2/login?redirect=${window.location.href}`)
+export const loginUrl = (redirect: string) => appUrl(`/oauth2/login?redirect=${redirect}`)
 


### PR DESCRIPTION
Gitt at man er logget inn i flaten og lar applikasjonen kjøre i en inaktiv fane så vil ikke fungere å sette window.location.href. Derfor kan bruker fortsette å trykke i brukergrensesnittet, men vil få en network error uten å nå backenden vår, som igjen trigger alarmer som er vanskelige å tolke siden de mangler status kode.

https://trello.com/c/D2FK1BNe/730-alarmer-i-frontend