### PR TITLE
Add blob: til script-src csp

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -89,7 +89,8 @@ spec:
                   "nav.boost.ai",
                   "'unsafe-inline'",
                   "'unsafe-eval'",
-                  "'self'"
+                  "'self'",
+                  "blob:"
                 ]
               }
             }

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -88,7 +88,8 @@ spec:
                   "nav.boost.ai",
                   "'unsafe-inline'",
                   "'unsafe-eval'",
-                  "'self'"
+                  "'self'",
+                  "blob:"
                 ]
               }
             }


### PR DESCRIPTION
Kreves i worker-src, som poao-frontend ikke setter, for dekoratøren, script-src brukes som fallback.