### PR TITLE
Justerer bredde på kolonner og statuser i deltakerliste

### DIFF
--- a/src/component/felles/status-merkelapp/StatusMerkelapp.module.scss
+++ b/src/component/felles/status-merkelapp/StatusMerkelapp.module.scss
@@ -8,9 +8,29 @@
 .statusTagOrange {
   background-color: var(--a-surface-warning-subtle);
   border-color: var(--a-border-warning);
+
 }
 
 .statusTagHvit {
   background-color: white;
   border-color: $navGra80;
+}
+
+.statusTagBlaSmall {
+  white-space: nowrap;
+  min-width: fit-content;
+
+  @media (min-width: 800px) and (max-width: 1350px) {
+      min-width: 70px;
+      max-width: 70px;
+      white-space: normal;
+  }
+}
+
+.statusTagOrangeSmall {
+  min-width: fit-content;
+
+  @media (min-width: 800px) and (max-width: 1350px) {
+      white-space: nowrap;
+  }
 }

--- a/src/component/felles/status-merkelapp/StatusMerkelapp.tsx
+++ b/src/component/felles/status-merkelapp/StatusMerkelapp.tsx
@@ -1,4 +1,5 @@
 import { Tag } from '@navikt/ds-react'
+import classNames from 'classnames'
 import React from 'react'
 
 import { DeltakerStatus, TiltakDeltakerStatus } from '../../../api/data/deltaker'
@@ -14,14 +15,25 @@ const getStyle = (statusType: TiltakDeltakerStatus) => {
 	}
 }
 
+const deltakerlisteStyle = (statusType: TiltakDeltakerStatus) => {
+	switch (statusType) {
+		case TiltakDeltakerStatus.IKKE_AKTUELL:
+		case TiltakDeltakerStatus.HAR_SLUTTET: return styles.statusTagOrangeSmall
+		case TiltakDeltakerStatus.VENTER_PA_OPPSTART: return styles.statusTagBlaSmall
+		case TiltakDeltakerStatus.DELTAR: 
+		default: return undefined
+	}
+}
+
 interface StatusProps {
     status: DeltakerStatus
+		erDeltakerlisteVisning?: boolean
 }
 
 export const StatusMerkelapp = (props: StatusProps) => {
 	const { type } = props.status
 	return(
-		<Tag variant="info" size="small" className={getStyle(type)}>
+		<Tag variant="info" size="small" className={classNames(getStyle(type), props.erDeltakerlisteVisning ? deltakerlisteStyle(type) : undefined)}>
 			{mapTiltakDeltagerStatusTilTekst(type)}
 		</Tag>
 	)

--- a/src/component/page/deltakerliste-detaljer/deltaker-oversikt/deltaker-tabell/DeltakerTabell.tsx
+++ b/src/component/page/deltakerliste-detaljer/deltaker-oversikt/deltaker-tabell/DeltakerTabell.tsx
@@ -11,6 +11,10 @@ interface Props {
 	onSortChange: (v: string | undefined) => void
 }
 
+/* 
+ * Det er en forholdsvis stor andel brukere med skjermbredde på 1280px så ideelt sett bør 
+ * tabellen ikke ha en horisontalscroll på skjermbredder >= 1280px
+ */
 export const DeltakerTabell = ({
 	deltakere,
 	sortering,

--- a/src/component/page/deltakerliste-detaljer/deltaker-oversikt/deltaker-tabell/Rad.tsx
+++ b/src/component/page/deltakerliste-detaljer/deltaker-oversikt/deltaker-tabell/Rad.tsx
@@ -67,7 +67,7 @@ export const Rad = (props: RadProps): React.ReactElement<RadProps> => {
 			<Table.DataCell>{startDatoTekst}</Table.DataCell>
 			<Table.DataCell>{sluttDatoTekst}</Table.DataCell>
 			<Table.DataCell>
-				<StatusMerkelapp status={status} />
+				<StatusMerkelapp status={status} erDeltakerlisteVisning />
 			</Table.DataCell>
 			<Show if={toggle.veilederEnabled}>
 				<Table.DataCell>

--- a/src/component/page/deltakerliste-detaljer/deltaker-oversikt/deltaker-tabell/TabellHeader.tsx
+++ b/src/component/page/deltakerliste-detaljer/deltaker-oversikt/deltaker-tabell/TabellHeader.tsx
@@ -16,26 +16,26 @@ function fixedWidth(pixels: number): React.CSSProperties {
 export const TabellHeader = () => (
 	<Table.Header>
 		<Table.Row>
-			<Table.ColumnHeader sortKey={DeltakerKolonne.NAVN} style={dynamicWidth(230)} sortable>
+			<Table.ColumnHeader sortKey={DeltakerKolonne.NAVN} style={dynamicWidth(200)} sortable>
 				Etternavn, Fornavn
 			</Table.ColumnHeader>
-			<Table.ColumnHeader sortKey={DeltakerKolonne.FODSELSNUMMER} style={fixedWidth(128)} sortable>
+			<Table.ColumnHeader sortKey={DeltakerKolonne.FODSELSNUMMER} style={fixedWidth(90)} sortable>
 				Fødselsnr.
 			</Table.ColumnHeader>
-			<Table.ColumnHeader sortKey={DeltakerKolonne.SOKT_INN} style={fixedWidth(120)} sortable>
-				Søkt inn
+			<Table.ColumnHeader sortKey={DeltakerKolonne.SOKT_INN} style={fixedWidth(90)} sortable>
+				Søkt&nbsp;inn
 			</Table.ColumnHeader>
-			<Table.ColumnHeader sortKey={DeltakerKolonne.OPPSTART} style={fixedWidth(120)} sortable>
+			<Table.ColumnHeader sortKey={DeltakerKolonne.OPPSTART} style={fixedWidth(90)} sortable>
 				Oppstart
 			</Table.ColumnHeader>
-			<Table.ColumnHeader sortKey={DeltakerKolonne.SLUTT} style={fixedWidth(120)} sortable>
+			<Table.ColumnHeader sortKey={DeltakerKolonne.SLUTT} style={fixedWidth(90)} sortable>
 				Slutt
 			</Table.ColumnHeader>
-			<Table.ColumnHeader sortKey={DeltakerKolonne.STATUS} style={fixedWidth(168)} sortable>
+			<Table.ColumnHeader sortKey={DeltakerKolonne.STATUS} style={dynamicWidth(70)} sortable>
 				Status
 			</Table.ColumnHeader>
 			<Show if={toggle.veilederEnabled}>
-				<Table.ColumnHeader sortKey={DeltakerKolonne.VEILEDER} style={dynamicWidth(200)} sortable>
+				<Table.ColumnHeader sortKey={DeltakerKolonne.VEILEDER} style={dynamicWidth(160)} sortable>
 					Veileder
 				</Table.ColumnHeader>
 			</Show>


### PR DESCRIPTION
Det er en forholdsvis stor andel brukere med skjermbredde på 1280px så ideelt sett bør tabeller ikke ha en horisontalscroll på skjermbredder >= 1280px.