### PR TITLE
Fikse fokus for checkboxer, forenkle oppdater filter store for å passe CheckboxGroup

### DIFF
--- a/src/component/felles/table-filter/FilterMeny.tsx
+++ b/src/component/felles/table-filter/FilterMeny.tsx
@@ -30,15 +30,15 @@ const FilterCheckbox = (entry: FiltermenyDataEntry) => {
 export const FilterMeny = (props: Props) => {
 	return (
 		<ExpansionCard
-			className={ styles.expansionCard }
+			className={styles.expansionCard}
 			size="small"
-			aria-label={ props.navn }
+			aria-label={props.navn}
 		>
 			<ExpansionCard.Header>
-				<ExpansionCard.Title size="small" as="h4" >{ props.navn }</ExpansionCard.Title>
+				<ExpansionCard.Title size="small" as="h4" >{props.navn}</ExpansionCard.Title>
 			</ExpansionCard.Header>
 
-			<ExpansionCard.Content className={ styles.expansionContent } >
+			<ExpansionCard.Content className={styles.expansionContent} >
 				<CheckboxGroup
 					legend=""
 					className={styles.checkboxGroup}

--- a/src/component/felles/table-filter/FilterMeny.tsx
+++ b/src/component/felles/table-filter/FilterMeny.tsx
@@ -33,6 +33,8 @@ export const FilterMeny = (props: Props) => {
 			className={styles.expansionCard}
 			size="small"
 			aria-label={props.navn}
+			open={props.open}
+			onToggle={props.onToggle}
 		>
 			<ExpansionCard.Header>
 				<ExpansionCard.Title size="small" as="h4" >{props.navn}</ExpansionCard.Title>

--- a/src/component/felles/table-filter/FilterMeny.tsx
+++ b/src/component/felles/table-filter/FilterMeny.tsx
@@ -10,50 +10,41 @@ interface Props {
 	filter: string[]
 	open: boolean
 	onToggle: (f: boolean) => void
-	addFilter: (f: string) => void
-	removeFilter: (f: string) => void,
+	updateFilter: ( f: string[] ) => void
+}
+
+const FilterCheckbox = (entry: FiltermenyDataEntry) => {
+	return (
+		<Checkbox
+			className={styles.checkbox}
+			value={entry.id}
+		>
+			<span className={styles.content}>
+				<span>{entry.displayName}</span>
+				<span className={styles.occurrences}>{entry.antallDeltakere}</span>
+			</span>
+		</Checkbox>
+	)
 }
 
 export const FilterMeny = (props: Props) => {
-	const FilterCheckbox = (entry: FiltermenyDataEntry) => {
-		return (
-			<Checkbox
-				className={styles.checkbox}
-				onChange={(e) => {
-					if (e.target.checked) {
-						props.addFilter(entry.id)
-					} else {
-						props.removeFilter(entry.id)
-					}
-				}}
-				value={entry.id}
-			>
-				<span className={styles.content}>
-					<span>{entry.displayName}</span>
-					<span className={styles.occurrences}>{entry.antallDeltakere}</span>
-				</span>
-			</Checkbox>
-		)
-	}
-
 	return (
 		<ExpansionCard
-			className={styles.expansionCard}
+			className={ styles.expansionCard }
 			size="small"
-			aria-label={props.navn}
-			open={props.open}
-			onToggle={props.onToggle}
+			aria-label={ props.navn }
 		>
 			<ExpansionCard.Header>
 				<ExpansionCard.Title size="small" as="h4" >{ props.navn }</ExpansionCard.Title>
 			</ExpansionCard.Header>
 
-			<ExpansionCard.Content className={styles.expansionContent} >
+			<ExpansionCard.Content className={ styles.expansionContent } >
 				<CheckboxGroup
 					legend=""
 					className={styles.checkboxGroup}
 					aria-label={`Filtrer deltakere på ${props.navn}`}
 					value={props.filter}
+					onChange={( newFilter: string[] ) => props.updateFilter( newFilter )}
 				>
 					{props.data.map( ( e: FiltermenyDataEntry ) => (
 						<FilterCheckbox key={e.id} id={e.id} displayName={e.displayName} antallDeltakere={e.antallDeltakere} />

--- a/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyMedveileder.tsx
+++ b/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyMedveileder.tsx
@@ -17,8 +17,7 @@ export const FilterMenyMedveileder = (props: Props): React.ReactElement => {
 
 	const {
 		medveilederFilter,
-		addMedveilederFilter,
-		removeMedveilederFilter,
+		updateMedveilederFilter,
 		statusFilter,
 		veilederFilter,
 		filtrerDeltakere,
@@ -55,7 +54,6 @@ export const FilterMenyMedveileder = (props: Props): React.ReactElement => {
 
 	useEffect(() => {
 		const map = createInitialDataMap()
-		filtrerDeltakere(props.deltakere)
 		filtrerDeltakerePaaAltUtenom(FilterType.Medveileder, props.deltakere).forEach((deltaker) => {
 			const medveiledere = getMedveiledere(deltaker)
 
@@ -89,10 +87,9 @@ export const FilterMenyMedveileder = (props: Props): React.ReactElement => {
 			data={deltakerePerMedveileder}
 			className={globalStyles.blokkXs}
 			filter={medveilederFilter}
-			open={ filterOpen }
-			onToggle={ () => { setFilterOpen(!filterOpen) } }
-			addFilter={addMedveilederFilter}
-			removeFilter={removeMedveilederFilter}
+			open={filterOpen}
+			onToggle={() => {setFilterOpen( !filterOpen )}}
+			updateFilter={updateMedveilederFilter}
 		/>
 	)
 }

--- a/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyNavKontor.tsx
+++ b/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyNavKontor.tsx
@@ -1,7 +1,7 @@
 import { TiltakDeltaker } from '../../../../api/data/deltaker'
 import React, { useEffect, useState } from 'react'
 import { FiltermenyDataEntry } from '../../../felles/table-filter/filtermeny-data-entry'
-import { useKoordinatorFilterMenyStore } from '../store/koordinator-filter-meny-store-provider'
+import { FilterType, useKoordinatorFilterMenyStore } from '../store/koordinator-filter-meny-store-provider'
 import { FilterMeny } from '../../../felles/table-filter/FilterMeny'
 import globalStyles from '../../../../globals.module.scss'
 import useLocalStorage from '../../../../hooks/useLocalStorage'
@@ -19,9 +19,8 @@ export const FilterMenyNavKontor = (props: Props): React.ReactElement => {
 		medveilederFilter,
 		statusFilter,
 		navKontorFilter,
-		addNavKontorFilter,
-		removeNavKontorFilter,
-		filtrerDeltakere
+		updateNavKontorFilter,
+		filtrerDeltakerePaaAltUtenom
 	} = useKoordinatorFilterMenyStore()
 
 	const createInitialDataMap = (deltakere: TiltakDeltaker[]): Map<string, FiltermenyDataEntry> => {
@@ -45,7 +44,7 @@ export const FilterMenyNavKontor = (props: Props): React.ReactElement => {
 	useEffect(() => {
 		const map = createInitialDataMap(props.deltakere)
 
-		filtrerDeltakere(props.deltakere)
+		filtrerDeltakerePaaAltUtenom(FilterType.NavKontor, props.deltakere)
 			.forEach((deltaker) => {
 				const navkontor = deltaker.navKontor
 
@@ -61,7 +60,7 @@ export const FilterMenyNavKontor = (props: Props): React.ReactElement => {
 			})
 
 		setDeltakerePerNavKontor([ ...map.values() ])
-	}, [ props.deltakere, statusFilter, medveilederFilter, veilederFilter, filtrerDeltakere ])
+	}, [ props.deltakere, statusFilter, medveilederFilter, veilederFilter, filtrerDeltakerePaaAltUtenom ])
 
 	return (
 		<FilterMeny
@@ -71,8 +70,7 @@ export const FilterMenyNavKontor = (props: Props): React.ReactElement => {
 			filter={navKontorFilter}
 			open={filterOpen}
 			onToggle={() => {setFilterOpen( !filterOpen )}}
-			addFilter={addNavKontorFilter}
-			removeFilter={removeNavKontorFilter}
+			updateFilter={ updateNavKontorFilter }
 		/>
 	)
 }

--- a/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyNavKontor.tsx
+++ b/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyNavKontor.tsx
@@ -70,7 +70,7 @@ export const FilterMenyNavKontor = (props: Props): React.ReactElement => {
 			filter={navKontorFilter}
 			open={filterOpen}
 			onToggle={() => {setFilterOpen( !filterOpen )}}
-			updateFilter={ updateNavKontorFilter }
+			updateFilter={updateNavKontorFilter}
 		/>
 	)
 }

--- a/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyStatus.tsx
+++ b/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyStatus.tsx
@@ -8,7 +8,6 @@ import globalStyles from '../../../../globals.module.scss'
 import { FilterMeny } from '../../../felles/table-filter/FilterMeny'
 import { mapTiltakDeltakerStatusTilTekst } from '../../../../utils/text-mappers'
 import { FiltermenyDataEntry } from '../../../felles/table-filter/filtermeny-data-entry'
-import { klikkFilterMeny, loggKlikk } from '../../../../utils/amplitude-utils'
 import useLocalStorage from '../../../../hooks/useLocalStorage'
 
 interface Props {
@@ -22,8 +21,7 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 
 	const {
 		statusFilter,
-		addStatusFilter,
-		removeStatusFilter,
+		updateStatusFilter,
 		medveilederFilter,
 		veilederFilter,
 		filtrerDeltakere,
@@ -49,7 +47,6 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 	useEffect(() => {
 		const statusMap = createInitialDataMap()
 
-		filtrerDeltakere(props.deltakere)
 		filtrerDeltakerePaaAltUtenom(FilterType.Status, props.deltakere).forEach((deltaker: TiltakDeltaker) => {
 			const status = deltaker.status.type
 			const entry = statusMap.get(status)
@@ -64,26 +61,15 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 		setDeltakerePerStatus([ ...statusMap.values() ])
 	}, [ props.deltakere, medveilederFilter, veilederFilter, filtrerDeltakere, createInitialDataMap, filtrerDeltakerePaaAltUtenom ])
 
-	const leggTil = (status: string) => {
-		addStatusFilter(status)
-		loggKlikk(klikkFilterMeny, status, 'checked')
-	}
-
-	const fjern = (status: string) => {
-		removeStatusFilter(status)
-		loggKlikk(klikkFilterMeny, status, 'unchecked')
-	}
-
 	return (
 		<FilterMeny
 			navn="Status"
 			data={deltakerePerStatus}
 			className={globalStyles.blokkXs}
 			filter={statusFilter}
-			open={ filterOpen }
-			onToggle={ () => { setFilterOpen(!filterOpen) } }
-			addFilter={leggTil}
-			removeFilter={fjern}
+			open={filterOpen}
+			onToggle={() => {setFilterOpen( !filterOpen )}}
+			updateFilter={updateStatusFilter}
 		/>
 	)
 }

--- a/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyVeiledere.tsx
+++ b/src/component/page/deltakerliste-detaljer/filter-meny/FilterMenyVeiledere.tsx
@@ -17,8 +17,7 @@ export const FilterMenyVeiledere = (props: Props): React.ReactElement => {
 
 	const {
 		veilederFilter,
-		addVeilederFilter,
-		removeVeilederFilter,
+		updateVeilederFilter,
 		medveilederFilter,
 		statusFilter,
 		filtrerDeltakere,
@@ -57,7 +56,6 @@ export const FilterMenyVeiledere = (props: Props): React.ReactElement => {
 	useEffect(() => {
 		const map = createInitialDataMap()
 
-		filtrerDeltakere(props.deltakere)
 		filtrerDeltakerePaaAltUtenom(FilterType.Veileder, props.deltakere).forEach((deltaker) => {
 			const hovedveileder = getHovedveileder(deltaker)
 
@@ -90,10 +88,9 @@ export const FilterMenyVeiledere = (props: Props): React.ReactElement => {
 			data={deltakerePerVeileder}
 			className={globalStyles.blokkXs}
 			filter={veilederFilter}
-			open={ filterOpen }
-			onToggle={ () => { setFilterOpen(!filterOpen) } }
-			addFilter={addVeilederFilter}
-			removeFilter={removeVeilederFilter}
+			open={filterOpen}
+			onToggle={() => {setFilterOpen( !filterOpen )}}
+			updateFilter={updateVeilederFilter}
 		/>
 	)
 }

--- a/src/component/page/deltakerliste-detaljer/store/koordinator-filter-meny-store-provider.ts
+++ b/src/component/page/deltakerliste-detaljer/store/koordinator-filter-meny-store-provider.ts
@@ -10,7 +10,11 @@ import {
 import { VeilederMedType } from '../../../../api/data/veileder'
 
 export enum FilterType {
-	Ingen, Status, Veileder, Medveileder, NavKontor
+	Ingen,
+	Status,
+	Veileder,
+	Medveileder,
+	NavKontor
 }
 export const [ KoordinatorFilterMenyStoreProvider, useKoordinatorFilterMenyStore ] = constate(() => {
 	const [ veilederFilter, setVeilederFilter ] = useState<string[]>([])
@@ -18,24 +22,17 @@ export const [ KoordinatorFilterMenyStoreProvider, useKoordinatorFilterMenyStore
 	const [ statusFilter, setStatusFilter ] = useState<string[]>([])
 	const [ navKontorFilter, setNavKontorFilter ] = useState<string[]>([])
 
-	const addStatusFilter = (status: string) => addFilter(status, statusFilter, setStatusFilter)
+	const updateStatusFilter = (newFilter: string[]) => setStatusFilter(newFilter)
 	const removeStatusFilter = (status: string) => removeFilter(status, statusFilter, setStatusFilter)
 
-	const addVeilederFilter = (status: string) => addFilter(status, veilederFilter, setVeilederFilter)
+	const updateVeilederFilter = (newFilter: string[]) => setVeilederFilter(newFilter)
 	const removeVeilederFilter = (status: string) => removeFilter(status, veilederFilter, setVeilederFilter)
 
-	const addMedveilederFilter = (status: string) => addFilter(status, medveilederFilter, setMedveilederFilter)
+	const updateMedveilederFilter = (newFilter: string[]) => setMedveilederFilter(newFilter)
 	const removeMedveilederFilter = (status: string) => removeFilter(status, medveilederFilter, setMedveilederFilter)
 
-	const addNavKontorFilter = (status: string) => addFilter(status, navKontorFilter, setNavKontorFilter)
+	const updateNavKontorFilter = (newFilter: string[]) => setNavKontorFilter(newFilter)
 	const removeNavKontorFilter = (status: string) => removeFilter(status, navKontorFilter, setNavKontorFilter)
-
-
-	const addFilter = ((value: string, filterValue: string[], setFilter: (value: string[]) => void) => {
-		if(!filterValue.includes(value)) {
-			setFilter([ ...filterValue, value ])
-		}
-	})
 
 	const removeFilter = (value: string, filterValue: string[], setFilter: (value: string[]) => void) =>
 		setFilter(filterValue.filter((v) => v !== value))
@@ -52,36 +49,37 @@ export const [ KoordinatorFilterMenyStoreProvider, useKoordinatorFilterMenyStore
 
 	const matcherMedveileder = (brukersMedveiledere: VeilederMedType[]) => {
 		if (medveilederFilter.length === 0) return true
-		if (brukersMedveiledere.length === 0 && medveilederFilter.includes(HAR_IKKE_MEDVEILEDER_FILTER_TEKST)) return true
+		if (brukersMedveiledere.length === 0 && medveilederFilter.includes(HAR_IKKE_MEDVEILEDER_FILTER_TEKST))
+			return true
 
 		let retVal = false
-		brukersMedveiledere.forEach(medveileder => {
+		brukersMedveiledere.forEach((medveileder) => {
 			if (medveilederFilter.includes(medveileder.ansattId)) retVal = true
 		})
 
 		return retVal
 	}
 
-	const matcherNavKontor = (brukersNavKontor: string|null) => {
+	const matcherNavKontor = (brukersNavKontor: string | null) => {
 		if (navKontorFilter.length === 0) return true
 		if (brukersNavKontor === null) return false
 		return navKontorFilter.includes(brukersNavKontor)
 	}
 
 	const filtrerDeltakerePaStatus = (deltakere: TiltakDeltaker[]): TiltakDeltaker[] => {
-		return deltakere.filter(bruker => matcherStatus(statusFilter, bruker.status.type))
+		return deltakere.filter((bruker) => matcherStatus(statusFilter, bruker.status.type))
 	}
 
 	const filtrerDeltakereMedHovedveileder = (deltakere: TiltakDeltaker[]): TiltakDeltaker[] => {
-		return deltakere.filter(bruker => matcherVeileder(getHovedveileder(bruker)))
+		return deltakere.filter((bruker) => matcherVeileder(getHovedveileder(bruker)))
 	}
 
 	const filtrerDeltakereMedMedveileder = (brukere: TiltakDeltaker[]): TiltakDeltaker[] => {
-		return brukere.filter(bruker => matcherMedveileder(getMedveiledere(bruker)))
+		return brukere.filter((bruker) => matcherMedveileder(getMedveiledere(bruker)))
 	}
 
 	const filtrerDeltakerePaNavKontor = (deltakere: TiltakDeltaker[]): TiltakDeltaker[] => {
-		return deltakere.filter(bruker => matcherNavKontor(bruker.navKontor))
+		return deltakere.filter((bruker) => matcherNavKontor(bruker.navKontor))
 	}
 
 	const filtrerDeltakere = (deltakere: TiltakDeltaker[]): TiltakDeltaker[] => {
@@ -89,27 +87,32 @@ export const [ KoordinatorFilterMenyStoreProvider, useKoordinatorFilterMenyStore
 	}
 
 	const filtrerDeltakerePaaAltUtenom = (filterType: FilterType, deltakere: TiltakDeltaker[]) => {
-		const filtrertPaStatus = filterType == FilterType.Status? deltakere: filtrerDeltakerePaStatus(deltakere)
-		const filtrertPaVeiledere = filterType === FilterType.Veileder? filtrertPaStatus: filtrerDeltakereMedHovedveileder(filtrertPaStatus)
-		const filtrertPaMedveileder = filterType == FilterType.Medveileder? filtrertPaVeiledere: filtrerDeltakereMedMedveileder(filtrertPaVeiledere)
-		return filterType == FilterType.NavKontor? filtrertPaMedveileder: filtrerDeltakerePaNavKontor(filtrertPaMedveileder)
+		const filtrertPaStatus = filterType == FilterType.Status ? deltakere : filtrerDeltakerePaStatus(deltakere)
+		const filtrertPaVeiledere =
+			filterType === FilterType.Veileder ? filtrertPaStatus : filtrerDeltakereMedHovedveileder(filtrertPaStatus)
+		const filtrertPaMedveileder =
+			filterType == FilterType.Medveileder
+				? filtrertPaVeiledere
+				: filtrerDeltakereMedMedveileder(filtrertPaVeiledere)
+		return filterType == FilterType.NavKontor
+			? filtrertPaMedveileder
+			: filtrerDeltakerePaNavKontor(filtrertPaMedveileder)
 	}
 
 	return {
 		veilederFilter,
-		addVeilederFilter,
+		updateVeilederFilter,
 		removeVeilederFilter,
 		medveilederFilter,
-		addMedveilederFilter,
+		updateMedveilederFilter,
 		removeMedveilederFilter,
 		statusFilter,
-		addStatusFilter,
+		updateStatusFilter,
 		removeStatusFilter,
 		navKontorFilter,
-		addNavKontorFilter,
+		updateNavKontorFilter,
 		removeNavKontorFilter,
 		filtrerDeltakere,
 		filtrerDeltakerePaaAltUtenom
 	}
-
 })

--- a/src/component/page/veileder/filter-meny/FilterMenyDeltakerliste.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyDeltakerliste.tsx
@@ -16,8 +16,7 @@ export const FilterMenyDeltakerliste = (props: Props): ReactElement => {
 
 	const {
 		deltakerlisteFilter,
-		addDeltakerlisteFilter,
-		removeDeltakerlisteFilter,
+		updateDeltakerlisteFilter,
 		statusFilter,
 		veiledertypeFilter,
 		filtrerDeltakere,
@@ -41,7 +40,7 @@ export const FilterMenyDeltakerliste = (props: Props): ReactElement => {
 
 	useEffect(() => {
 		const data = createInitialDataMap(props.deltakere)
-		filtrerDeltakere(props.deltakere)
+
 		filtrerDeltakerePaaAltUtenom(FilterType.Deltakerliste, props.deltakere).forEach((deltaker: VeiledersDeltaker) => {
 			const deltakerliste = deltaker.deltakerliste
 
@@ -63,10 +62,9 @@ export const FilterMenyDeltakerliste = (props: Props): ReactElement => {
 			data={deltakerlister}
 			className={globalStyles.blokkXs}
 			filter={deltakerlisteFilter}
-			open={ filterOpen }
-			onToggle={ () => { setFilterOpen(!filterOpen) } }
-			addFilter={addDeltakerlisteFilter}
-			removeFilter={removeDeltakerlisteFilter}
+			open={filterOpen}
+			onToggle={() => {setFilterOpen( !filterOpen )}}
+			updateFilter={updateDeltakerlisteFilter}
 		/>
 	)
 }

--- a/src/component/page/veileder/filter-meny/FilterMenyStatus.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyStatus.tsx
@@ -17,15 +17,15 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 
 	const {
 		statusFilter,
+		veiledertypeFilter,
+		deltakerlisteFilter,
 		updateStatusFilter,
-		filtrerDeltakere,
 		filtrerDeltakerePaaAltUtenom
 	} = useVeilederFilterMenyStore()
 
 	useEffect(() => {
 		const statuser = { ...KursDeltakerStatuser, ...IndividuellDeltakerStatus }
-		const deltakereFiltrert = filtrerDeltakerePaaAltUtenom(FilterType.Status, props.deltakere)
-		filtrerDeltakere(props.deltakere)
+		const deltakereFiltrert = filtrerDeltakerePaaAltUtenom( FilterType.Status, props.deltakere )
 
 		const statusMap =  Object.keys(statuser).reduce((list: Map<string, FiltermenyDataEntry>, status: string) => {
 			const antallDeltakereTotalt = deltakereFiltrert.filter(deltaker => deltaker.status.type === status).length
@@ -37,7 +37,7 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 			})}, new Map<string, FiltermenyDataEntry>())
 
 		setDeltakerePerStatus([ ...statusMap.values() ])
-	}, [ props.deltakere, filtrerDeltakere, filtrerDeltakerePaaAltUtenom ])
+	}, [ props.deltakere, veiledertypeFilter, deltakerlisteFilter, filtrerDeltakerePaaAltUtenom ] )
 
 	return (
 		<FilterMeny

--- a/src/component/page/veileder/filter-meny/FilterMenyStatus.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyStatus.tsx
@@ -2,7 +2,6 @@ import { IndividuellDeltakerStatus, KursDeltakerStatuser, VeiledersDeltaker } fr
 import React, { useEffect, useState } from 'react'
 import { FiltermenyDataEntry } from '../../../felles/table-filter/filtermeny-data-entry'
 import { mapTiltakDeltakerStatusTilTekst } from '../../../../utils/text-mappers'
-import { klikkFilterMeny, loggKlikk } from '../../../../utils/amplitude-utils'
 import { FilterMeny } from '../../../felles/table-filter/FilterMeny'
 import globalStyles from '../../../../globals.module.scss'
 import { FilterType, useVeilederFilterMenyStore } from '../store/veileder-filter-meny-store-provider'
@@ -18,8 +17,7 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 
 	const {
 		statusFilter,
-		addStatusFilter,
-		removeStatusFilter,
+		updateStatusFilter,
 		filtrerDeltakere,
 		filtrerDeltakerePaaAltUtenom
 	} = useVeilederFilterMenyStore()
@@ -41,26 +39,15 @@ export const FilterMenyStatus = (props: Props): React.ReactElement => {
 		setDeltakerePerStatus([ ...statusMap.values() ])
 	}, [ props.deltakere, filtrerDeltakere, filtrerDeltakerePaaAltUtenom ])
 
-	const leggTil = (status: string) => {
-		addStatusFilter(status)
-		loggKlikk(klikkFilterMeny, status, 'checked')
-	}
-
-	const fjern = (status: string) => {
-		removeStatusFilter(status)
-		loggKlikk(klikkFilterMeny, status, 'unchecked')
-	}
-
 	return (
 		<FilterMeny
 			navn="Status"
 			data={deltakerePerStatus}
 			className={globalStyles.blokkXs}
 			filter={statusFilter}
-			open={ filterOpen }
-			onToggle={ () => { setFilterOpen(!filterOpen) } }
-			addFilter={leggTil}
-			removeFilter={fjern}
+			open={filterOpen}
+			onToggle={() => {setFilterOpen( !filterOpen )}}
+			updateFilter={updateStatusFilter}
 		/>
 	)
 }

--- a/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
@@ -42,7 +42,7 @@ export const FilterMenyVeilederType = (props: Props): React.ReactElement => {
 		}
 
 		const data = createInitialDataMap(props.deltakere)
-		filtrerDeltakere(props.deltakere)
+
 		filtrerDeltakerePaaAltUtenom(FilterType.VeilederType, props.deltakere).forEach((deltaker: VeiledersDeltaker) => {
 			const veilederType = tilVeiledertype(deltaker.veiledertype === Veiledertype.MEDVEILEDER)
 			const entry = data.get(veilederType)

--- a/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
@@ -56,6 +56,8 @@ export const FilterMenyVeilederType = (props: Props): React.ReactElement => {
 		setDeltakerePerVeiledertype([ ...data.values() ])
 	}, [ props.deltakere, statusFilter, deltakerlisteFilter, filtrerDeltakere, filtrerDeltakerePaaAltUtenom ])
 
+	console.log( 'filterOpen', filterOpen )
+
 	return (
 		<FilterMeny
 			navn="Type veileder"

--- a/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
@@ -56,8 +56,6 @@ export const FilterMenyVeilederType = (props: Props): React.ReactElement => {
 		setDeltakerePerVeiledertype([ ...data.values() ])
 	}, [ props.deltakere, statusFilter, deltakerlisteFilter, filtrerDeltakere, filtrerDeltakerePaaAltUtenom ])
 
-	console.log( 'filterOpen', filterOpen )
-
 	return (
 		<FilterMeny
 			navn="Type veileder"

--- a/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
+++ b/src/component/page/veileder/filter-meny/FilterMenyVeilederType.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import { FiltermenyDataEntry } from '../../../felles/table-filter/filtermeny-data-entry'
 import { FilterType, useVeilederFilterMenyStore } from '../store/veileder-filter-meny-store-provider'
 import { tilVeiledertype } from '../../../../utils/deltakerliste-utils'
-import { klikkFilterMeny, loggKlikk } from '../../../../utils/amplitude-utils'
 import globalStyles from '../../../../globals.module.scss'
 import { FilterMeny } from '../../../felles/table-filter/FilterMeny'
 import { Veiledertype } from '../../../../api/data/veileder'
@@ -20,8 +19,7 @@ export const FilterMenyVeilederType = (props: Props): React.ReactElement => {
 
 	const {
 		veiledertypeFilter,
-		addVeilederTypeFilter,
-		removeVeilederTypeFilter,
+		updateVeilederTypeFilter,
 		statusFilter,
 		deltakerlisteFilter,
 		filtrerDeltakere,
@@ -58,26 +56,15 @@ export const FilterMenyVeilederType = (props: Props): React.ReactElement => {
 		setDeltakerePerVeiledertype([ ...data.values() ])
 	}, [ props.deltakere, statusFilter, deltakerlisteFilter, filtrerDeltakere, filtrerDeltakerePaaAltUtenom ])
 
-	const leggTil = (veiledertype: string) => {
-		addVeilederTypeFilter(veiledertype)
-		loggKlikk(klikkFilterMeny, veiledertype, 'checked')
-	}
-
-	const fjern = (veiledertype: string) => {
-		removeVeilederTypeFilter(veiledertype)
-		loggKlikk(klikkFilterMeny, veiledertype, 'unchecked')
-	}
-
 	return (
 		<FilterMeny
 			navn="Type veileder"
 			data={deltakerePerVeiledertype}
 			className={globalStyles.blokkXs}
 			filter={veiledertypeFilter}
-			open={ filterOpen }
-			onToggle={ () => { setFilterOpen(!filterOpen) } }
-			addFilter={leggTil}
-			removeFilter={fjern}
+			open={filterOpen}
+			onToggle={() => {setFilterOpen( !filterOpen )}}
+			updateFilter={updateVeilederTypeFilter}
 		/>
 	)
 }

--- a/src/component/page/veileder/store/veileder-filter-meny-store-provider.ts
+++ b/src/component/page/veileder/store/veileder-filter-meny-store-provider.ts
@@ -5,30 +5,25 @@ import { tilVeiledertype } from '../../../../utils/deltakerliste-utils'
 import { Veiledertype } from '../../../../api/data/veileder'
 
 export enum FilterType {
-	Ingen, Status, VeilederType, Deltakerliste
+	Ingen,
+	Status,
+	VeilederType,
+	Deltakerliste
 }
 export const [ VeilederFilterMenyStoreProvider, useVeilederFilterMenyStore ] = constate(() => {
 	const [ statusFilter, setStatusFilter ] = useState<string[]>([])
 	const [ deltakerlisteFilter, setDeltakerlisteFilter ] = useState<string[]>([])
 	const [ veiledertypeFilter, setVeiledertypeFilter ] = useState<string[]>([ Veiledertype.VEILEDER ])
 
-	const addStatusFilter = (status: string) => addFilter(status, statusFilter, setStatusFilter)
-
+	const updateStatusFilter = (newFilter: string[]) => setStatusFilter(newFilter)
 	const removeStatusFilter = (status: string) => removeFilter(status, statusFilter, setStatusFilter)
 
-	const addVeilederTypeFilter = (status: string) => addFilter(status, veiledertypeFilter, setVeiledertypeFilter)
-
+	const updateVeilederTypeFilter = (newFilter: string[]) => setVeiledertypeFilter(newFilter)
 	const removeVeilederTypeFilter = (status: string) => removeFilter(status, veiledertypeFilter, setVeiledertypeFilter)
 
-	const addDeltakerlisteFilter = (status: string) => addFilter(status, deltakerlisteFilter, setDeltakerlisteFilter)
-
-	const removeDeltakerlisteFilter = (status: string) => removeFilter(status, deltakerlisteFilter, setDeltakerlisteFilter)
-
-	const addFilter = ((value: string, filterValue: string[], setFilter: (value: string[]) => void) => {
-		if(!filterValue.includes(value)) {
-			setFilter([ ...filterValue, value ])
-		}
-	})
+	const updateDeltakerlisteFilter = (newFilter: string[]) => setDeltakerlisteFilter(newFilter)
+	const removeDeltakerlisteFilter = (status: string) =>
+		removeFilter(status, deltakerlisteFilter, setDeltakerlisteFilter)
 
 	const removeFilter = (value: string, filterValue: string[], setFilter: (value: string[]) => void) =>
 		setFilter(filterValue.filter((v) => v !== value))
@@ -49,15 +44,17 @@ export const [ VeilederFilterMenyStoreProvider, useVeilederFilterMenyStore ] = c
 	}
 
 	const filtrerDeltakerePaStatus = (deltakere: VeiledersDeltaker[]): VeiledersDeltaker[] => {
-		return deltakere.filter(bruker => matcherStatus(statusFilter, bruker.status.type))
+		return deltakere.filter((bruker) => matcherStatus(statusFilter, bruker.status.type))
 	}
 
 	const filtrerDeltakerePaDeltakerliste = (deltakere: VeiledersDeltaker[]): VeiledersDeltaker[] => {
-		return deltakere.filter(bruker => matcherDeltakerliste(bruker.deltakerliste.navn))
+		return deltakere.filter((bruker) => matcherDeltakerliste(bruker.deltakerliste.navn))
 	}
 
 	const filtrerDeltakerePaVeiledertype = (deltakere: VeiledersDeltaker[]): VeiledersDeltaker[] => {
-		return deltakere.filter(bruker => matcherVeiledertype(tilVeiledertype(bruker.veiledertype === Veiledertype.MEDVEILEDER)))
+		return deltakere.filter((bruker) =>
+			matcherVeiledertype(tilVeiledertype(bruker.veiledertype === Veiledertype.MEDVEILEDER))
+		)
 	}
 
 	const filtrerDeltakere = (deltakere: VeiledersDeltaker[]): VeiledersDeltaker[] => {
@@ -65,23 +62,25 @@ export const [ VeilederFilterMenyStoreProvider, useVeilederFilterMenyStore ] = c
 	}
 
 	const filtrerDeltakerePaaAltUtenom = (filterType: FilterType, deltakere: VeiledersDeltaker[]) => {
-		const filtrertPaStatus = filterType == FilterType.Status? deltakere: filtrerDeltakerePaStatus(deltakere)
-		const filtrertPaVeiledertype = filterType == FilterType.VeilederType? filtrertPaStatus: filtrerDeltakerePaVeiledertype(filtrertPaStatus)
-		return filterType == FilterType.Deltakerliste? filtrertPaVeiledertype: filtrerDeltakerePaDeltakerliste(filtrertPaVeiledertype)
+		const filtrertPaStatus = filterType == FilterType.Status ? deltakere : filtrerDeltakerePaStatus(deltakere)
+		const filtrertPaVeiledertype =
+			filterType == FilterType.VeilederType ? filtrertPaStatus : filtrerDeltakerePaVeiledertype(filtrertPaStatus)
+		return filterType == FilterType.Deltakerliste
+			? filtrertPaVeiledertype
+			: filtrerDeltakerePaDeltakerliste(filtrertPaVeiledertype)
 	}
 
 	return {
 		statusFilter,
-		addStatusFilter,
+		updateStatusFilter,
 		removeStatusFilter,
 		veiledertypeFilter,
-		addVeilederTypeFilter,
+		updateVeilederTypeFilter,
 		removeVeilederTypeFilter,
 		deltakerlisteFilter,
-		addDeltakerlisteFilter,
+		updateDeltakerlisteFilter,
 		removeDeltakerlisteFilter,
 		filtrerDeltakere,
 		filtrerDeltakerePaaAltUtenom
 	}
-
 })


### PR DESCRIPTION
https://trello.com/c/DSy0FaNr/1004-filtermeny-tastaturnavigering-nullstilles-ved-check-uncheck-av-checkboksene-fokus-blir-flyttet-til-starten-av-checkboxgroup