### PR TITLE
Ikke vise legg til oppstartsdato for AFT når vi er master og status er IKKE_AKTUELL

### DIFF
--- a/src/component/page/bruker-detaljer/deltaker-detaljer/EndreDeltakelseKnapp.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/EndreDeltakelseKnapp.tsx
@@ -37,6 +37,10 @@ export const EndreDeltakelseKnapp = (props: EndreDeltakelseKnappProps) => {
     lukkModal
   } = useModalData()
   const { deltaker } = props
+
+  const kanIkkeLeggeTilOppstartDato = deltaker.status.type === TiltakDeltakerStatus.IKKE_AKTUELL
+    && props.erForslagEnabled
+
   const kanEndreStartDato =
     deltaker.status.type === TiltakDeltakerStatus.VENTER_PA_OPPSTART ||
     deltaker.status.type === TiltakDeltakerStatus.IKKE_AKTUELL ||
@@ -70,7 +74,7 @@ export const EndreDeltakelseKnapp = (props: EndreDeltakelseKnappProps) => {
         </Button>
         <Dropdown.Menu className={styles.dropdownMenu}>
           <Dropdown.Menu.List>
-            {kanEndreStartDato && !deltaker.startDato && (
+            {kanEndreStartDato && !kanIkkeLeggeTilOppstartDato && !deltaker.startDato && (
               <DropDownButton
                 endringstype={EndringType.LEGG_TIL_OPPSTARTSDATO}
                 onClick={() =>


### PR DESCRIPTION
https://trello.com/c/SjMgILMK/1780-bug-hvis-har-status-ikke-aktuell-og-klikker-p%C3%A5-legg-til-oppstartsdato-s%C3%A5-lagres-det-ikke