### PR TITLE
endrer toggle så vi alltid er master for AFT

### DIFF
--- a/src/hooks/useFeatureToggle.ts
+++ b/src/hooks/useFeatureToggle.ts
@@ -10,7 +10,10 @@ import { Tiltakskode } from '../api/data/tiltak'
 
 let cachedFeatureToggles: FeatureToggles | undefined = undefined
 
-const tiltakstyperMedForslag = [Tiltakskode.ARBFORB]
+const tiltakstyperKometAlltidErMasterFor
+  = [Tiltakskode.ARBFORB]
+
+const tiltakstyperKometKanskjeErMasterFor: Tiltakskode[] = []
 
 export const useFeatureToggle = () => {
   const [toggles, setToggles] = useState<FeatureToggles>()
@@ -28,8 +31,9 @@ export const useFeatureToggle = () => {
 
   const erKometMasterForTiltak = (tiltakstype: Tiltakskode) => {
     if (
-      toggles?.[KOMET_DELTAKERE_TOGGLE_NAVN] &&
-      tiltakstyperMedForslag.includes(tiltakstype)
+      tiltakstyperKometAlltidErMasterFor.includes(tiltakstype) ||
+      (toggles?.[KOMET_DELTAKERE_TOGGLE_NAVN] &&
+      tiltakstyperKometKanskjeErMasterFor.includes(tiltakstype))
     )
       return true
     return false


### PR DESCRIPTION
https://trello.com/c/2jW2Jep2/1803-etter-lansering-endre-i-appene-som-sjekker-om-komet-er-master-for-deltakere-slik-at-komet-alltid-er-master-for-aft