### PR TITLE
Forleng deltakelse skal ikke være tilgjengelig når bruker mangler sluttdato

### DIFF
--- a/src/component/page/bruker-detaljer/deltaker-detaljer/EndreDeltakelseKnapp.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/EndreDeltakelseKnapp.tsx
@@ -55,9 +55,9 @@ export const EndreDeltakelseKnapp = (props: EndreDeltakelseKnappProps) => {
 
   const visGodkjennVilkaarPanel = deltaker.tiltakskode !== Tiltakskode.VASV
   const kanHaSenereSluttdato =
-    !deltaker.sluttDato ||
     !deltaker.deltakerliste.sluttDato ||
-    deltaker.sluttDato < deltaker.deltakerliste.sluttDato
+      (deltaker.sluttDato && (deltaker.sluttDato < deltaker.deltakerliste.sluttDato))
+
   return (
     <>
       <ModalController modalData={modalData} onClose={handleCloseModal} />


### PR DESCRIPTION
https://trello.com/c/WJB0LDTe/1938-vta-forslag-og-endring-forlengelse-skal-kun-v%C3%A6re-tilgjengelig-n%C3%A5r-brukeren-har-registrert-en-sluttdatoDette er i utgangspunktet et scenario for VTA som ofte mangler sluttdato