### PR TITLE
Vis forleng deltakelse kun hvis vi har sluttdato hvis status er DELTAR

### DIFF
--- a/src/component/page/bruker-detaljer/deltaker-detaljer/EndreDeltakelseKnapp.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/EndreDeltakelseKnapp.tsx
@@ -55,9 +55,6 @@ export const EndreDeltakelseKnapp = (props: EndreDeltakelseKnappProps) => {
   }
 
   const visGodkjennVilkaarPanel = deltaker.tiltakskode !== Tiltakskode.VASV
-  const kanHaSenereSluttdato =
-    !deltaker.deltakerliste.sluttDato ||
-      (deltaker.sluttDato && (deltaker.sluttDato < deltaker.deltakerliste.sluttDato))
 
   return (
     <>
@@ -109,7 +106,7 @@ export const EndreDeltakelseKnapp = (props: EndreDeltakelseKnappProps) => {
 
             {(deltaker.status.type === TiltakDeltakerStatus.HAR_SLUTTET ||
               (deltaker.status.type === TiltakDeltakerStatus.DELTAR &&
-                kanHaSenereSluttdato)) && (
+                deltaker.sluttDato)) && (
               <DropDownButton
                 endringstype={EndringType.FORLENG_DELTAKELSE}
                 onClick={() =>


### PR DESCRIPTION
https://trello.com/c/J1H2Dfwl/2011-bug-forleng-deltakelse-skal-ikke-v%C3%A6re-et-valg-n%C3%A5r-deltaker-ikke-har-registrert-en-sluttdato-vta