### PR TITLE
Skjuler sluttdato fra endringer på startdato hvis sluttdato ikke er oppgitt

### DIFF
--- a/src/component/page/bruker-detaljer/deltaker-detaljer/forslag/ForslagEndringsdetaljer.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/forslag/ForslagEndringsdetaljer.tsx
@@ -105,9 +105,11 @@ function EndringsDetaljer({ endring }: { readonly endring: ForslagEndring }) {
           <BodyLong size="small">
             Ny oppstartsdato: {formatDate(endring.startdato)}
           </BodyLong>
-          <BodyLong size="small">
-            Forventet sluttdato: {formatDate(endring.sluttdato)}
-          </BodyLong>
+          {endring.sluttdato && (
+            <BodyLong size="small">
+              Forventet sluttdato: {formatDate(endring.sluttdato)}
+            </BodyLong>
+          )}
         </>
       )
     case ForslagEndringType.Sluttarsak:

--- a/src/component/page/bruker-detaljer/deltaker-detaljer/historikk/HistorikkArrangorEndring.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/historikk/HistorikkArrangorEndring.tsx
@@ -26,10 +26,10 @@ const getEndringsTittel = (endring: ArrangorEndring) => {
 const getEndringsDetaljer = (endring: ArrangorEndring) => {
   switch (endring.type) {
     case ArrangorEndringsType.LeggTilOppstartsdato:
-      return (
-        <BodyLong size="small">
-          Forventet sluttdato: {formatDate(endring.sluttdato)}
-        </BodyLong>
+      return endring.sluttdato && (
+          <BodyLong size="small">
+            Forventet sluttdato: {formatDate(endring.sluttdato)}
+          </BodyLong>
       )
   }
 }

--- a/src/component/page/bruker-detaljer/deltaker-detaljer/historikk/HistorikkElement.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/historikk/HistorikkElement.tsx
@@ -111,9 +111,11 @@ export const ForslagtypeDetaljer = ({
             <BodyLong size="small">
               Ny oppstartsdato: {formatDate(forslag.endring.startdato)}
             </BodyLong>
-            <BodyLong size="small">
-              Forventet sluttdato: {formatDate(forslag.endring.sluttdato)}
-            </BodyLong>
+            {forslag.endring.sluttdato && (
+              <BodyLong size="small">
+                Forventet sluttdato: {formatDate(forslag.endring.sluttdato)}
+              </BodyLong>
+            )}
           </>
         )
       case ForslagEndringType.Sluttarsak:

--- a/src/component/page/bruker-detaljer/deltaker-detaljer/historikk/HistorikkEndring.tsx
+++ b/src/component/page/bruker-detaljer/deltaker-detaljer/historikk/HistorikkEndring.tsx
@@ -113,9 +113,11 @@ const getEndringsDetaljer = (endring: Endring, tiltakstype: Tiltakskode) => {
     case EndringType.EndreStartdato: {
       return (
         <>
-          <BodyLong size="small">
-            Forventet sluttdato: {formatDate(endring.sluttdato)}
-          </BodyLong>
+          {endring.sluttdato && (
+            <BodyLong size="small">
+                Forventet sluttdato: {formatDate(endring.sluttdato)}
+            </BodyLong>
+          )}
           {endring.begrunnelse && (
             <BodyLong size="small" className={globalStyles.textPreWrap}>
               Navs begrunnelse: {endring.begrunnelse}


### PR DESCRIPTION
https://trello.com/c/G94Wmoer/1957-endre-startdato-vta-ta-bort-varighet-sluttdato-dersom-deltaker-ikke-har-en-sluttdato