### PR TITLE
fjerner historiske vurderinger som uansett ikke brukes

### DIFF
--- a/src/api/data/deltaker.ts
+++ b/src/api/data/deltaker.ts
@@ -183,7 +183,6 @@ export const deltakerSchema = z.object({
   historiskeEndringsmeldinger: z.array(endringsmeldingSchema).nullable(),
   adresse: adresseSchema.nullable(),
   gjeldendeVurderingFraArrangor: vurderingSchema.nullable(),
-  historiskeVurderingerFraArrangor: z.array(vurderingSchema).nullable(),
   adressebeskyttet: z.boolean(),
   deltakelsesmengder: deltakelsesmengderSchema.nullable()
 })

--- a/src/mock/data/brukere.ts
+++ b/src/mock/data/brukere.ts
@@ -77,7 +77,6 @@ export interface MockTiltakDeltaker {
   veiledere: VeilederMedType[]
   adresse: MockAdresse | null
   gjeldendeVurderingFraArrangor: MockVurdering | null
-  historiskeVurderingerFraArrangor: MockVurdering[] | null
   adressebeskyttet: boolean
   erVeilederForDeltaker: boolean
   deltakelsesmengder: Deltakelsesmengder | null
@@ -229,10 +228,6 @@ const lagVurdering = (erHistorisk: boolean): MockVurdering => {
   }
 }
 
-const lagHistoriskeVurderinger = (): MockVurdering[] => {
-  return new Array(randBetween(0, 3)).fill(null).map(() => lagVurdering(true))
-}
-
 const lagMockTiltakDeltagerForGjennomforing = (
   gjennomforing: Gjennomforing
 ): MockTiltakDeltaker => {
@@ -343,9 +338,6 @@ const lagMockTiltakDeltagerForGjennomforing = (
     veiledere: lagMockVeiledereForDeltaker(id),
     adresse: lagAdresse(),
     gjeldendeVurderingFraArrangor,
-    historiskeVurderingerFraArrangor: gjeldendeVurderingFraArrangor
-      ? lagHistoriskeVurderinger()
-      : null,
     erVeilederForDeltaker: false,
     adressebeskyttet: false,
     deltakelsesmengder: {

--- a/src/mock/handlers/mock-handlers.ts
+++ b/src/mock/handlers/mock-handlers.ts
@@ -588,7 +588,6 @@ const mapToDeltakerDetaljerView = (
         }
       : null,
     gjeldendeVurderingFraArrangor: deltaker.gjeldendeVurderingFraArrangor,
-    historiskeVurderingerFraArrangor: deltaker.historiskeVurderingerFraArrangor,
     adressebeskyttet: deltaker.adressebeskyttet,
     deltakelsesmengder: deltaker.deltakelsesmengder
   }


### PR DESCRIPTION
https://trello.com/c/vWhuVSEK/2059-amt-tiltaksarrangor-bff-m%C3%A5-dele-vurdering-fra-arrang%C3%B8r-p%C3%A5-topic

Disse brukes ikke i dag, og hvis vi skal vise historiske vurderinger blir det vel mest sannsynlig som en del av historikken. 